### PR TITLE
Add proper (and super fast) .h dependency checking to the 850C build

### DIFF
--- a/firmware/850C/.gitignore
+++ b/firmware/850C/.gitignore
@@ -5,3 +5,5 @@
 build
 debug
 .dep
+
+common

--- a/firmware/850C/src/.gitignore
+++ b/firmware/850C/src/.gitignore
@@ -1,1 +1,3 @@
 main.map
+.deps
+_build

--- a/firmware/850C/src/Makefile
+++ b/firmware/850C/src/Makefile
@@ -66,8 +66,9 @@ ODFLAGS = -S
 include ../../common/Makefile.common
 
 COMMONSRC = ../../common/src
+OBJDIR = _build
 SOURCES=$(shell find spl ugui_driver *.c -type f -iname '*.c') $(COMMONSRC)/fault.c $(COMMONSRC)/buttons.c $(COMMONSRC)/utils.c $(COMMONSRC)/ugui.c $(COMMONSRC)/fonts.c $(COMMONSRC)/state.c $(COMMONSRC)/screen.c $(COMMONSRC)/mainscreen.c $(COMMONSRC)/configscreen.c $(COMMONSRC)/eeprom.c
-OBJECTS=$(foreach x, $(basename $(SOURCES)), $(x).o)
+OBJECTS = $(foreach x, $(basename $(SOURCES)), $(OBJDIR)/$(x).o)
 
 # dev platform specific.
 # OPENOCD_PATH := E:/nrf5/Toolchain/OpenOCD/0.10.0-12-20190422-2015/bin
@@ -82,12 +83,12 @@ OPENOCD := '$(OPENOCD_PATH)/$(OPENOCD_BIN)' -f $(OPENOCD_PATH)/../scripts/interf
 
 all: main.bin size
 
+test:
+	echo objs $(OBJECTS)
+
 clean: 
 	rm -f main.lst main.elf main.bin
-	rm $(COMMONSRC)/*.o
-	find *.o | xargs rm
-	find spl/src/*.o | xargs rm
-	find spl/CMSIS/*.o | xargs rm
+	rm -rf $(OBJDIR) .deps
 
 flash_serial: main.bin 
 	$(STM32FLASH) main.bin
@@ -119,9 +120,26 @@ main.elf: $(OBJECTS) startup_stm32f10x_md.o
 	@echo "..linking"
 	$(LD)  $^ $(LFLAGS) -o $@
 
-%.o: %.c
-	@echo ".compiling"
-	$(CC) $(CFLAGS) $< -o $@
-
 startup_stm32f10x_md.o:
 	$(AS) $(ASFLAGS) startup_stm32f10x_md.s -o startup_stm32f10x_md.o
+
+#
+# The following makefile magic generates proper dependencies for headerfiles, so that if you change a headerfile
+# the correct C files that use it will be recompiled 
+DEPDIR := .deps
+DEPFLAGS = -MT $@ -MD -MP -MF $(DEPDIR)/$*.d
+
+COMPILE.c = $(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c
+
+%.o : %.c
+$(OBJDIR)/%.o : %.c $(DEPDIR)/%.d | $(DEPDIR)
+	@mkdir -p $(dir $@) $(DEPDIR)/$(dir $<)
+	# @echo ".compiling"
+	$(COMPILE.c) $(OUTPUT_OPTION) $< 
+	
+$(DEPDIR): ; @mkdir -p $@
+
+DEPFILES := $(SOURCES:%.c=$(DEPDIR)/%.d)
+$(DEPFILES):
+
+include $(wildcard $(DEPFILES))

--- a/firmware/850C/src/Makefile
+++ b/firmware/850C/src/Makefile
@@ -65,9 +65,11 @@ ODFLAGS = -S
 
 include ../../common/Makefile.common
 
-COMMONSRC = ../../common/src
+COMMONDIR = ../../common/src
 OBJDIR = _build
-SOURCES=$(shell find spl ugui_driver *.c -type f -iname '*.c') $(COMMONSRC)/fault.c $(COMMONSRC)/buttons.c $(COMMONSRC)/utils.c $(COMMONSRC)/ugui.c $(COMMONSRC)/fonts.c $(COMMONSRC)/state.c $(COMMONSRC)/screen.c $(COMMONSRC)/mainscreen.c $(COMMONSRC)/configscreen.c $(COMMONSRC)/eeprom.c
+CUSTOM_SOURCES=$(shell find spl ugui_driver *.c -type f -iname '*.c') 
+COMMON_SOURCES = fault.c buttons.c utils.c ugui.c fonts.c state.c screen.c mainscreen.c configscreen.c eeprom.c
+SOURCES = $(CUSTOM_SOURCES) $(foreach x, $(COMMON_SOURCES), $(COMMONDIR)/$(x))
 OBJECTS = $(foreach x, $(basename $(SOURCES)), $(OBJDIR)/$(x).o)
 
 # dev platform specific.
@@ -83,6 +85,7 @@ OPENOCD := '$(OPENOCD_PATH)/$(OPENOCD_BIN)' -f $(OPENOCD_PATH)/../scripts/interf
 
 all: main.bin size
 
+# Ignore - useful for debugging makefiles
 test:
 	echo objs $(OBJECTS)
 
@@ -131,10 +134,8 @@ DEPFLAGS = -MT $@ -MD -MP -MF $(DEPDIR)/$*.d
 
 COMPILE.c = $(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c
 
-%.o : %.c
 $(OBJDIR)/%.o : %.c $(DEPDIR)/%.d | $(DEPDIR)
 	@mkdir -p $(dir $@) $(DEPDIR)/$(dir $<)
-	# @echo ".compiling"
 	$(COMPILE.c) $(OUTPUT_OPTION) $< 
 	
 $(DEPDIR): ; @mkdir -p $@
@@ -142,4 +143,4 @@ $(DEPDIR): ; @mkdir -p $@
 DEPFILES := $(SOURCES:%.c=$(DEPDIR)/%.d)
 $(DEPFILES):
 
-include $(wildcard $(DEPFILES))
+include $(wildcard $(DEPFILES)) 

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -4,4 +4,4 @@
 # Build both SW102 and 850C targets
 all:
 	cd SW102; make
-	cd 850C/src; make clean; make
+	cd 850C/src; make 

--- a/firmware/SW102/.settings/language.settings.xml
+++ b/firmware/SW102/.settings/language.settings.xml
@@ -5,7 +5,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="true" name="CDT GCC Build Output Parser" parameter="(.*gcc)|(.*[gc]\+\+)" prefer-non-shared="true"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="15379769813821362" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-231984418745443324" id="ilg.gnuarmeclipse.managedbuild.cross.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT ARM Cross GCC Built-in Compiler Settings " parameter="${COMMAND} ${FLAGS} ${cross_toolchain_flags} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/firmware/common/Makefile.common
+++ b/firmware/common/Makefile.common
@@ -4,7 +4,7 @@
 
 
 # The integer build number for this release, MUST BE INCREMENTED FOR EACH RELEASE SO BOOTLOADER WILL INSTALL
-VERSION_NUM := 18
+VERSION_NUM := 19
 
 VERSION_STRING := 0.5.0-beta.3
 


### PR DESCRIPTION
This:
a) makes incremental builds while developing  much much faster - almost instant
b) no need to do "make clean" for the 850c unless for some reason you feel like it
c) prevent crashes/bugs that come from changing a .h file - previously the makefile would not notice that change and therefore some .c files that might depend on that file (i.e. structure defs) might not rebuild

Also: I've added a toplevel makefile.  I'd encourage everyone to do "make" in the firmware directory before checking code in.  To make sure your changes don't break the build for other platforms.