### PR TITLE
Streetmode Hotkey Disable Option and more

### DIFF
--- a/firmware/common/include/eeprom.h
+++ b/firmware/common/include/eeprom.h
@@ -89,6 +89,7 @@ typedef struct eeprom_data {
   uint8_t ui8_street_mode_speed_limit;
   uint8_t ui8_street_mode_power_limit_div25;
   uint8_t ui8_street_mode_throttle_enabled;
+  uint8_t ui8_street_mode_hotkey_enabled;
 
 #ifndef SW102
 	Graph_eeprom graph_eeprom[VARS_SIZE];
@@ -274,6 +275,7 @@ void eeprom_init_defaults(void);
 #define DEFAULT_STREET_MODE_SPEED_LIMIT                             25 // 25 km/h
 #define DEFAULT_STREET_MODE_POWER_LIMIT                             10 // 250W --> 250 / 25 = 10
 #define DEFAULT_STREET_MODE_THROTTLE_ENABLE                         0 // disabled
+#define DEFAULT_STREET_MODE_HOTKEY_ENABLE                           0 // disabled
 #define DEFAULT_PEDAL_CADENCE_FAST_STOP_ENABLE                      1 // enabled
 #define DEFAULT_COAST_BRAKE_ADC                                     15 // 15: tested by plpetrov user on 28.04.2020:
 #define DEFAULT_FIELD_WEAKENING                                     1 // 1 enabled

--- a/firmware/common/include/eeprom.h
+++ b/firmware/common/include/eeprom.h
@@ -15,8 +15,8 @@
 
 // For compatible changes, just add new fields at the end of the table (they will be inited to 0xff for old eeprom images).  For incompatible
 // changes bump up EEPROM_MIN_COMPAT_VERSION and the user's EEPROM settings will be discarded.
-#define EEPROM_MIN_COMPAT_VERSION 0x3A
-#define EEPROM_VERSION 0x3A
+#define EEPROM_MIN_COMPAT_VERSION 0x3B
+#define EEPROM_VERSION 0x3B
 
 typedef struct {
   graph_auto_max_min_t auto_max_min;

--- a/firmware/common/include/state.h
+++ b/firmware/common/include/state.h
@@ -257,6 +257,7 @@ typedef struct ui_vars_struct {
 	uint8_t ui8_street_mode_power_limit_div25;
 	uint16_t ui16_street_mode_power_limit;
 	uint8_t ui8_street_mode_throttle_enabled;
+	uint8_t ui8_street_mode_hotkey_enabled;
 
   uint16_t var_speed_graph_auto_max_min;
   uint16_t var_speed_graph_max_x10;

--- a/firmware/common/src/configscreen.c
+++ b/firmware/common/src/configscreen.c
@@ -164,10 +164,12 @@ static Field motorTempMenus[] =
 static Field streetModeMenus[] =
     {
       FIELD_EDITABLE_ENUM("Feature", &ui_vars.ui8_street_mode_function_enabled, "disable", "enable"),
+      FIELD_EDITABLE_ENUM(_S("Enable Mode", "Enabl Mode"), &ui_vars.ui8_street_mode_enabled, "no", "yes"),
       FIELD_EDITABLE_ENUM(_S("Enable at startup", "Enabl stup"), &ui_vars.ui8_street_mode_enabled_on_startup, "no", "yes"),
       FIELD_EDITABLE_UINT(_S("Speed limit", "Speed limt"), &ui_vars.ui8_street_mode_speed_limit, "kph", 1, 99, .div_digits = 0, .inc_step = 1, .hide_fraction = true),
       FIELD_EDITABLE_UINT(_S("Motor power limit", "Power limt"), &ui_vars.ui16_street_mode_power_limit, "watts", 25, 2500, .div_digits = 0, .inc_step = 25, .hide_fraction = true),
       FIELD_EDITABLE_ENUM(_S("Throttle enable", "Throt enab"), &ui_vars.ui8_street_mode_throttle_enabled, "no", "yes"),
+      FIELD_EDITABLE_ENUM(_S("Hotkey enable", "HotKy enab"), &ui_vars.ui8_street_mode_hotkey_enabled, "no", "yes"),
     FIELD_END };
 
 static Field displayMenus[] =

--- a/firmware/common/src/eeprom.c
+++ b/firmware/common/src/eeprom.c
@@ -270,6 +270,7 @@ const eeprom_data_t m_eeprom_data_defaults = {
   .ui8_street_mode_speed_limit = DEFAULT_STREET_MODE_SPEED_LIMIT,
   .ui8_street_mode_power_limit_div25 = DEFAULT_STREET_MODE_POWER_LIMIT,
   .ui8_street_mode_throttle_enabled = DEFAULT_STREET_MODE_THROTTLE_ENABLE,
+  .ui8_street_mode_hotkey_enabled = DEFAULT_STREET_MODE_HOTKEY_ENABLE,
   .ui8_pedal_cadence_fast_stop = DEFAULT_PEDAL_CADENCE_FAST_STOP_ENABLE,
   .ui8_coast_brake_adc = DEFAULT_COAST_BRAKE_ADC,
   .ui8_adc_lights_current_offset = DEFAULT_ADC_LIGHTS_CURRENT_OFFSET,

--- a/firmware/common/src/eeprom.c
+++ b/firmware/common/src/eeprom.c
@@ -559,6 +559,8 @@ void eeprom_init_variables(void) {
       m_eeprom_data.ui8_street_mode_power_limit_div25;
   ui_vars->ui8_street_mode_throttle_enabled =
       m_eeprom_data.ui8_street_mode_throttle_enabled;
+  ui_vars->ui8_street_mode_hotkey_enabled =
+      m_eeprom_data.ui8_street_mode_hotkey_enabled;
 
   ui_vars->ui8_pedal_cadence_fast_stop =
       m_eeprom_data.ui8_pedal_cadence_fast_stop;
@@ -743,6 +745,8 @@ void eeprom_write_variables(void) {
       ui_vars->ui8_street_mode_power_limit_div25;
   m_eeprom_data.ui8_street_mode_throttle_enabled =
       ui_vars->ui8_street_mode_throttle_enabled;
+  m_eeprom_data.ui8_street_mode_hotkey_enabled =
+      ui_vars->ui8_street_mode_hotkey_enabled;
 
   m_eeprom_data.ui8_pedal_cadence_fast_stop =
       ui_vars->ui8_pedal_cadence_fast_stop;

--- a/firmware/common/src/mainscreen.c
+++ b/firmware/common/src/mainscreen.c
@@ -410,7 +410,16 @@ static bool onPressAlternateField(buttons_events_t events) {
 
     // max power
     case 3:
-      if (events & SCREENCLICK_ALTERNATE_FIELD_START) {
+      if (
+        (
+          ui_vars.ui8_street_mode_function_enabled
+          && ui_vars.ui8_street_mode_enabled
+          && ui_vars.ui8_street_mode_throttle_enabled
+          || !ui_vars.ui8_street_mode_function_enabled
+          || !ui_vars.ui8_street_mode_enabled
+        )
+        && events & SCREENCLICK_ALTERNATE_FIELD_START
+      ) {
         ui8_m_alternate_field_state = 6;
         handled = true;
         break;
@@ -521,7 +530,7 @@ static bool onPressStreetMode(buttons_events_t events) {
 
   if (events & SCREENCLICK_STREET_MODE)
   {
-    if (ui_vars.ui8_street_mode_function_enabled)
+    if (ui_vars.ui8_street_mode_function_enabled && ui_vars.ui8_street_mode_hotkey_enabled)
     {
       if (ui_vars.ui8_street_mode_enabled)
         ui_vars.ui8_street_mode_enabled = 0;
@@ -529,8 +538,6 @@ static bool onPressStreetMode(buttons_events_t events) {
         ui_vars.ui8_street_mode_enabled = 1;
 
       mainScreenOnDirtyClean();
-    } else {
-      ui_vars.ui8_street_mode_enabled = 0;
     }
 
     handled = true;


### PR DESCRIPTION
Here is my PR to make the street mode more complaint to european laws.

- added option to disable streetmode hotkey (default disabled)
- disabling throttle also disables virtual throttle
- added option to enable streetmode without hotkey

let me know if you think a seperate option for the virtual throttle would be good.
i have set the street mode hotkey to be disabled by default because the other values were also set to commonly legal values. feel free to change it.

i will adjust the wiki when 1.0.0 releases.

Thank you!