### PR TITLE
Fix: write max battery current to eeprom

### DIFF
--- a/firmware/common/src/eeprom.c
+++ b/firmware/common/src/eeprom.c
@@ -595,6 +595,8 @@ void eeprom_write_variables(void) {
       ui_vars->ui8_time_field_enable;
   m_eeprom_data.ui8_target_max_battery_power_div25 =
       ui_vars->ui8_target_max_battery_power_div25;
+  m_eeprom_data.ui8_battery_max_current =
+      ui_vars->ui8_battery_max_current;
   m_eeprom_data.ui8_motor_max_current =
       ui_vars->ui8_motor_max_current;
   m_eeprom_data.ui8_motor_current_min_adc =


### PR DESCRIPTION
The battery max current setting is not written to the eeprom and always uses the default value of 16A on powerup.